### PR TITLE
Refactor WebSocket connection setup

### DIFF
--- a/src/pages/chat/chat.tsx
+++ b/src/pages/chat/chat.tsx
@@ -7,7 +7,12 @@ import { Overview } from "@/components/custom/overview";
 import { Header } from "@/components/custom/header";
 import {v4 as uuidv4} from 'uuid';
 
-const socket = new WebSocket("ws://localhost:8090"); //change to your websocket endpoint
+//const socket = new WebSocket("ws://localhost:8090"); //change to your websocket endpoint
+
+// get the device (instance)'s websocket endpoint
+const proto = window.location.protocol === "https:" ? "wss" : "ws";
+const host = window.location.hostname;
+const socket = new WebSocket(`${proto}://${host}:8090`);
 
 export function Chat() {
   const [messagesContainerRef, messagesEndRef] = useScrollToBottom<HTMLDivElement>();


### PR DESCRIPTION
hi

### issue:
So when I was using this template for my website, I forgot to change the hardcoded endpoint at `localhost:8090`, and spent a while debugging before I realized. So I found this more robust solution.

### sols
```
const proto = window.location.protocol === "https:" ? "wss" : "ws";
const host = window.location.hostname;
const socket = new WebSocket(`${proto}://${host}:8090`);
```
it just gets the protocol, the devivce ip, and then port 8090. pretty simple, works with linux & windows confirmed (probably macos but unsure )

This is better than hardcoding the socket var to the device ip for the following rzns:
- if the ec2/vm reboots, ip changes, so you have to manually update the code.
- elastic ips are not free, so you can't just set everything to elastic ip and then just hardcode

This works for aws ec2 instance, azure vm, and local devices.
Thank you

